### PR TITLE
Fixed the segmentation fault on Python module

### DIFF
--- a/py-rcsparse.c
+++ b/py-rcsparse.c
@@ -70,7 +70,7 @@ pyrcsrevtree_find_internal(struct pyrcsrevtree *self, PyObject *key, struct rcsr
 {
 	struct rcsrev rev;
 	struct rcstoken tok;
-	int l;
+	Py_ssize_t l;
 
 	if (!PyString_CheckExact(key))
 		return -1;
@@ -339,7 +339,7 @@ pyrcstokmap_find_internal(struct pyrcstokmap *self, PyObject *key, struct rcstok
 {
 	struct rcstokpair pair;
 	struct rcstoken tok;
-	int l;
+	Py_ssize_t l;
 
 	if (!PyString_CheckExact(key))
 		return -1;


### PR DESCRIPTION
I met the segmentation fault on Python 2.7
upon both Ubuntu 15.04 and Mac OSX 10.10.
python testmodule.py always segfault on `print s['RELENG_4']`.
I've confirmed that this problem can be fixed with patches
provided at OpenBSD ports devel/py-rcsparse, as said on issue #1.

2 patches applied as follows:
curl 'http://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/devel/py-rcsparse/patches/patch-py-rcsparse_c?rev=1.1&content-type=text/plain' | patch -p0
curl 'http://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/devel/py-rcsparse/patches/patch-rcsparse_c?rev=1.1&content-type=text/plain' | patch -p0
