### PR TITLE
Make py-rcsparse.c and testmodule.py can run on Python 3.

### DIFF
--- a/py-rcsparse.c
+++ b/py-rcsparse.c
@@ -25,6 +25,19 @@
 #include "rcsparse.h"
 
 
+#if PY_MAJOR_VERSION >= 3
+#define PyString_AsStringAndSize	_PyUnicode_AsUTF8AndSize
+#define PyString_CheckExact		PyUnicode_CheckExact
+#define PyString_FromString		PyUnicode_FromString
+#define PyString_FromStringAndSize	PyUnicode_FromStringAndSize
+#endif
+
+static void
+_PyUnicode_AsUTF8AndSize(PyObject *obj, char **strp, Py_ssize_t *sizep)
+{
+	*strp = PyUnicode_AsUTF8AndSize(obj, sizep);
+}
+
 static PyObject *
 rcstoken2pystr(struct rcstoken *tok)
 {
@@ -124,7 +137,11 @@ rcsrev2py(struct rcsrev *rev)
 
 	return Py_BuildValue("NNNNNNN",
 			rcstoken2pystr(rev->rev),
+#if PY_MAJOR_VERSION >= 3
+			PyLong_FromLong(timegm(&tm)),
+#else
 			PyInt_FromLong(timegm(&tm)),
+#endif
 			rcstoken2pystr(rev->author),
 			rcstoken2pystr(rev->state),
 			rcstoklist2py(&rev->branches),
@@ -275,7 +292,7 @@ static void
 pyrcsrevtree_dealloc(struct pyrcsrevtree *self)
 {
 	Py_DECREF((PyObject *)self->pyrcs);
-	self->ob_type->tp_free(self);
+	Py_TYPE(self)->tp_free(self);
 }
 
 static PyMappingMethods pyrcsrevtree_mapmethods = {
@@ -300,7 +317,7 @@ static PyMethodDef pyrcsrevtree_methods[] = {
 };
 
 static PyTypeObject pyrcsrevtree_type = {
-	PyObject_HEAD_INIT(&PyType_Type)
+	PyVarObject_HEAD_INIT(&PyType_Type, 0)
 	.tp_name=		"rcsparse.rcsrevtree",
 	.tp_basicsize=		sizeof(struct pyrcsrevtree),
 	.tp_dealloc=		(destructor)pyrcsrevtree_dealloc,
@@ -496,7 +513,7 @@ static void
 pyrcstokmap_dealloc(struct pyrcstokmap *self)
 {
 	Py_DECREF((PyObject *)self->pyrcs);
-	self->ob_type->tp_free(self);
+	Py_TYPE(self)->tp_free(self);
 }
 
 static PyMappingMethods pyrcstokmap_mapmethods = {
@@ -521,7 +538,7 @@ static PyMethodDef pyrcstokmap_methods[] = {
 };
 
 static PyTypeObject pyrcstokmap_type = {
-	PyObject_HEAD_INIT(&PyType_Type)
+	PyVarObject_HEAD_INIT(&PyType_Type, 0)
 	.tp_name=		"rcsparse.rcstokmap",
 	.tp_basicsize=		sizeof(struct pyrcstokmap),
 	.tp_dealloc=		(destructor)pyrcstokmap_dealloc,
@@ -645,7 +662,11 @@ pyrcsfile_checkout(struct pyrcsfile *self, PyObject *args)
 	if (buf == NULL)
 		return PyErr_Format(PyExc_RuntimeError, "Error parsing");
 
+#if PY_MAJOR_VERSION >= 3
+	o = PyBytes_FromStringAndSize(buf, len);
+#else
 	o = PyString_FromStringAndSize(buf, len);
+#endif
 	free(buf);
 	return o;
 }
@@ -664,7 +685,11 @@ pyrcsfile_getlog(struct pyrcsfile *self, PyObject *args)
 	if (buf == NULL)
 		return PyErr_Format(PyExc_RuntimeError, "Error parsing");
 
+#if PY_MAJOR_VERSION >= 3
+	o = PyBytes_FromString(buf);
+#else
 	o = PyString_FromString(buf);
+#endif
 	free(buf);
 	return o;
 }
@@ -720,7 +745,7 @@ pyrcsfile_dealloc(struct pyrcsfile *self)
 	if (self->rcs != NULL)
 		rcsclose(self->rcs);
 
-	self->ob_type->tp_free(self);
+	Py_TYPE(self)->tp_free(self);
 }
 
 static PyGetSetDef pyrcsfile_getseters[] = {
@@ -761,21 +786,48 @@ static PyMethodDef pyrcsparse_methods[] = {
 	{NULL}
 };
 
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef moduledef = {
+	PyModuleDef_HEAD_INIT,
+	"rcsparse",		/* m_name */
+	"RCS file parser",	/* m_doc */
+	-1,			/* m_size */
+	pyrcsparse_methods,	/* m_methods */
+	NULL,			/* m_reload */
+	NULL,			/* m_traverse */
+	NULL,			/* m_clear */
+	NULL,			/* m_free */
+};
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define retnull return NULL
+
+PyMODINIT_FUNC
+PyInit_rcsparse(void)
+#else
+#define retnull return
+
 PyMODINIT_FUNC
 initrcsparse(void)
+#endif
 {
 	PyObject *m;
 
 	if (PyType_Ready(&pyrcsfile_type) < 0)
-		return;
+		retnull;
 	if (PyType_Ready(&pyrcstokmap_type) < 0)
-		return;
+		retnull;
 	if (PyType_Ready(&pyrcsrevtree_type) < 0)
-		return;
+		retnull;
 
+#if PY_MAJOR_VERSION >= 3
+	m = PyModule_Create(&moduledef);
+#else
 	m = Py_InitModule3("rcsparse", pyrcsparse_methods, "RCS file parser");
+#endif
 	if (m == NULL)
-		return;
+		retnull;
 
 	Py_INCREF(&pyrcsfile_type);
 	PyModule_AddObject(m, "rcsfile", (PyObject *)&pyrcsfile_type);
@@ -783,4 +835,8 @@ initrcsparse(void)
 	PyModule_AddObject(m, "rcstokmap", (PyObject *)&pyrcstokmap_type);
 	Py_INCREF(&pyrcsrevtree_type);
 	PyModule_AddObject(m, "rcsrevtree", (PyObject *)&pyrcsrevtree_type);
+
+#if PY_MAJOR_VERSION >= 3
+	return m;
+#endif
 }

--- a/testmodule.py
+++ b/testmodule.py
@@ -1,13 +1,13 @@
 import rcsparse
-import md5
 
 f=rcsparse.rcsfile('test,v')
-print f.head
-print f.branch
+print(f.head)
+print(f.branch)
 s=f.symbols
-print s['RELENG_4']
-print s.items()
+print(s['RELENG_4'])
+print(list(s.items()))
 r=f.revs
-i=r.items()
-print i
-print f.getlog(f.sym2rev('RELENG_4'))
+i=list(r.items())
+print(i)
+print(f.getlog(f.sym2rev('RELENG_4')).decode('ascii'))
+print('1.1' in r)


### PR DESCRIPTION
from OpenBSD ports, work with Stuart Henderson.

testmodule.py seem to run fine on both python 2.7 and python 3.8